### PR TITLE
Fix bug in evaluation code

### DIFF
--- a/eval/eval_hrbench.py
+++ b/eval/eval_hrbench.py
@@ -13,6 +13,8 @@ import base64
 import io
 from openai import OpenAI
 import requests
+import copy
+import pandas as pd
 
 
 parser = argparse.ArgumentParser()

--- a/eval/eval_vstar.py
+++ b/eval/eval_vstar.py
@@ -13,7 +13,7 @@ import base64
 import io
 from openai import OpenAI
 import requests
-
+from random import shuffle
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--model_name', type=str, default='qwen', help='Model name for result save')
@@ -127,7 +127,9 @@ def process(img_arg):
         anno = json.load(f)
     question = anno['question']
     options = anno['options']
-
+    correct_answer = anno['options'][0]
+    shuffle(options)
+    
     option_str = "\n"
     for i in range(len(options)):
         option_str += abc_map[i + 1] + '. ' + options[i] + '\n'
@@ -270,7 +272,8 @@ def process(img_arg):
     save_info = {}
     save_info['image'] = img
     save_info['question'] = question
-    save_info['answer'] = anno['options'][0]
+    save_info['answer'] = correct_answer
+    save_info['answer_choice'] = chr(ord('A') + options.index(correct_answer))
     save_info['pred_ans'] = output_text
     save_info['pred_output'] = print_messages
     save_info['status'] = status

--- a/eval/judge_result.py
+++ b/eval/judge_result.py
@@ -134,10 +134,11 @@ def process(line):
     line = line.strip()
     data = json.loads(line)
     question = data['question']
+    choice = data['answer_choice']
     answer = data['answer']
     pred_ans = data['pred_ans']
     pred_output = data['pred_output']
-    answer = 'A. ' + answer
+    answer = f"{choice}. {answer}"
 
     if '\\boxed' in pred_ans:
         pred_ans = pred_ans.split('\\boxed{')[1].split('}')[0]
@@ -145,12 +146,12 @@ def process(line):
     # rule base check
     acc_reward = 0.0
     if len(pred_ans)==1:
-        if pred_ans == 'A':
+        if pred_ans == choice: #'A':
             acc_reward = 1.0
         else:
             acc_reward = 0.0
     elif len(pred_ans) == 2 and '.' in pred_ans:
-        if 'A' in pred_ans:
+        if choice in pred_ans: #'A' in pred_ans:
             acc_reward = 1.0
         else:
             acc_reward = 0.0

--- a/eval/judge_result_hrbench.py
+++ b/eval/judge_result_hrbench.py
@@ -36,7 +36,7 @@ if args.eval_model_name is None:
 else:
     eval_model_name = args.eval_model_name
 
-hrbench_path = args.vstar_bench_path
+hrbench_path = args.hrbench_path
 result_root_path = args.save_path
 result_root_path = os.path.join(result_root_path, args.model_name)
 
@@ -129,6 +129,7 @@ def process(line):
     data = json.loads(line)
     question = data['question']
     answer = data['answer']
+    answer_str = data['answer_str']
     pred_ans = data['pred_ans']
     pred_output = data['pred_output']
     category = data['category']
@@ -148,7 +149,9 @@ def process(line):
             acc_reward = 1.0
         else:
             acc_reward = 0.0
-    elif answer in pred_ans:
+    # elif answer in pred_ans:
+    #     acc_reward = 1.0
+    elif answer_str in pred_ans:
         acc_reward = 1.0
     else:
         full_prompt = get_prompt(pred_ans, answer, question)


### PR DESCRIPTION
Thank you for open-sourcing your work and making it easy to reproduce results.

This PR mainly fixes some bugs in the code and inappropriate evaluation settings that may cause overestimated results:

(1) **In V Star Benchmark evaluation**, the options should be shuffled (as in the annotation file provided by the [official repo](https://huggingface.co/datasets/craigwu/vstar_bench/blob/main/test_questions.jsonl)), instead of always putting the correct choice on 'A'. Here's the difference:
```
No shuffle:
Run 1:
"direct_attributes": 91.30434782608695,
"relative_position": 85.52631578947368,
"overall": 89.00523560209425

Run 2:
"direct_attributes": 92.17391304347827,
"relative_position": 90.78947368421053,
"overall": 91.62303664921467

Shuffle options:
Run 1:
"direct_attributes": 86.08695652173914,
"relative_position": 81.57894736842105,
"overall": 84.29319371727748

Run 2:
"direct_attributes": 86.08695652173914,
"relative_position": 85.52631578947368,
"overall": 85.86387434554975
```
The variance might be attributed to a small sample size (only 191 samples in total for this bench) and the model itself.

(2) **In HRBench evaluation**, the rule-based check should check if the option string is in the prediction result, instead of the option itself (in `DeepEyes/eval/judge_result_hrbench.py`):
```
  # elif answer in pred_ans:
  elif answer_str in pred_ans:
      acc_reward = 1.0
```

Here's an example of a False Positive:
```
hr_bench_8k
No.30:
"question": "Which side of the car is the person sitting on?", 
"answer": "B", 
"answer_str": "Front (hood)", 
"pred_ans": "A. Back (trunk)"
```
The model predicts a wrong result ("A. Back (trunk)") that accidentally contains the correct option ('B'), which is falsely taken as accurate.

Here's the difference made by the fix:
```
Before fixing:
"hr_bench_4k": {
    "single": 0.915,
    "cross": 0.585,
    "overall": 0.75
},
"hr_bench_8k": {
    "single": 0.8475,
    "cross": 0.565,
    "overall": 0.70625
}

After fixing:
"hr_bench_4k": {
    "single": 0.91,
    "cross": 0.565,
    "overall": 0.7375
},
"hr_bench_8k": {
    "single": 0.8475,
    "cross": 0.54,
    "overall": 0.6937500000000001
}
```
